### PR TITLE
Fail fast if asc file is missing

### DIFF
--- a/InitialImplementation.py
+++ b/InitialImplementation.py
@@ -330,8 +330,14 @@ def run_java_command(species_file):
         print("Error:", result.stderr)
     except subprocess.CalledProcessError as e:
         print("Error occurred while running the Java command:", e)
+        print("Output:", e.stdout)
+        print("Error:", e.stderr)
+        return
 
     asc_file, tiff_file, html_file = generate_file_paths(species_file)
+    if not os.path.exists(asc_file):
+        print(f"Expected ASC output not found: {asc_file}")
+        return
     convert_asc_to_tiff(asc_file, tiff_file)
     # auc_value = extract_auc_from_html(html_file)
     # if auc_value is not None:


### PR DESCRIPTION
This is a reproducibility fix.

A couple of reasons this file could be missing, most tieing back to maxent failing for a given species. This is more of an issue because the onus is on the user to populate the input datasets, which could be malformed, and the onus is on the user to have an environment capable of running maxent.jar (eg java installed, enough resources).

Some reasons this could happen:

- maxent.jar is missing/not loadable
- Java is not installed
- sp_data_final/<species>.csv is missing/malformed
- `final_attributes/` is missing, incomplete, or unreadable
- environmental layers are in the wrong format/misaligned